### PR TITLE
fix circular chart path bug

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,4 +55,4 @@ runs:
         fi
         popd
       }
-      resolve-helm-chart-dependencies ${{ inputs.chart_path }}
+      resolve-helm-chart-dependencies .


### PR DESCRIPTION
remove circular path issue:
* working directory set to ${{ inputs.chart_path }}
* first call to function also set to ${{ inputs.chart_path }} <--- problem
* change first call to function to be `.` 